### PR TITLE
Change to correct specification url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-Read the specification at [orebrokommun.github.com/Open-Meal-Information](https://orebrokommun.github.com/Open-Meal-Information).
+Read the specification at [sambruk.github.io/Open-Meal](https://sambruk.github.io/Open-Meal).
 
 Site based on the [jekyll-docs-template](http://bruth.github.io/jekyll-docs-template/).


### PR DESCRIPTION
Changed the url in readme so it points to the proper sambruk.github.io 