### PR TITLE
Change 'orebrokommun.github.io'- and 'Open-Meal-Info' references to '…

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ subtitle: 'Open Data specification'
 navigation: 1
 
 # URL to source code, used in _includes/footer.html
-codeurl: 'https://github.com/Orebrokommun/Open-Meal-Information'
+codeurl: 'https://github.com/Sambruk/Open-Meal'
 
 # Default categories (in order) to appear in the navigation
 sections: [
@@ -24,7 +24,7 @@ sections: [
 
 # Keep as an empty string if served up at the root. If served up at a specific
 # path (e.g. on GitHub pages) leave off the trailing slash, e.g. /my-project
-baseurl: '/Open-Meal-Information'
+baseurl: '/Open-Meal'
 
 # Dates are not included in permalinks
 permalink: none

--- a/_posts/2014-12-18-list-data-providers.md
+++ b/_posts/2014-12-18-list-data-providers.md
@@ -10,7 +10,7 @@ This API method list all Data Providers that have implemented the Open Meal API 
 <table>
 	<tr>
 		<td>URL: </td>
-		<td><a href="https://raw.githubusercontent.com/Orebrokommun/Open-Meal-Information/master/dataproviders.json">https://raw.githubusercontent.com/Orebrokommun/Open-Meal-Information/master/dataproviders.json</a></td>
+		<td><a href="https://raw.githubusercontent.com/Sambruk/Open-Meal/master/dataproviders.json">https://raw.githubusercontent.com/Sambruk/Open-Meal/master/dataproviders.json</a></td>
 	</tr>
 	<tr>
 		<td>HTTP Method: </td>
@@ -47,7 +47,7 @@ The method returns a list of Data Providers, including name, contact information
 
 ##Example
 
-	GET https://raw.githubusercontent.com/Orebrokommun/Open-Meal-Information/master/dataproviders.json
+	GET https://raw.githubusercontent.com/Sambruk/Open-Meal/master/dataproviders.json
 
     {
 	    "data" : [

--- a/_posts/2015-06-05-dcatap.md
+++ b/_posts/2015-06-05-dcatap.md
@@ -5,9 +5,9 @@ category: doc
 date: 2014-12-17 16:48:56
 ---
 
-[DCAT-AP](https://joinup.ec.europa.eu/asset/dcat_application_profile/description) is a European specification of how to describe public sector datasets. Open Meal has [one DCAT-AP file](/Open-Meal-Information/datasets/dcat) to describe the central parts of the specification (i.e. List Data Providers) and one per Data Provider to describe their implementation of Open Meal.
+[DCAT-AP](https://joinup.ec.europa.eu/asset/dcat_application_profile/description) is a European specification of how to describe public sector datasets. Open Meal has [one DCAT-AP file](/Open-Meal/datasets/dcat) to describe the central parts of the specification (i.e. List Data Providers) and one per Data Provider to describe their implementation of Open Meal.
 
 ##Data Providers
-An example of a DCAT-AP file for Data Providers is available at [dataprovider-dcat-ap-example.rdf](/Open-Meal-Information/dataprovider-dcat-ap-example.rdf)
+An example of a DCAT-AP file for Data Providers is available at [dataprovider-dcat-ap-example.rdf](/Open-Meal/dataprovider-dcat-ap-example.rdf)
 
 Please change all URLs, email addresses and mentions of *Data Provider* into the relevant information.

--- a/_posts/2015-08-26-hur-gr-jag-tillvga.md
+++ b/_posts/2015-08-26-hur-gr-jag-tillvga.md
@@ -7,8 +7,8 @@ date: 2015-08-26 09:52:37
 
 När du bestämt dig för att vara med och bidra till att informationen om måltider blir tillgänglig för alla kan du göra följande:
 
-1. Ställ frågor till din befintliga leverantör av kostplaneringssystem: Kan ert system leverera öppna data enligt den nationella definitionen på [orebrokommun.github.io/Open-Meal-Information/](http://orebrokommun.github.io/Open-Meal-Information/)? Om så inte är fallet idag, när kommer det att ske?
+1. Ställ frågor till din befintliga leverantör av kostplaneringssystem: Kan ert system leverera öppna data enligt den nationella definitionen på [sambruk.github.io/Open-Meal/](https://sambruk.github.io/Open-Meal/)? Om så inte är fallet idag, när kommer det att ske?
 
-2. Ställ krav på leverantörer vid upphandling av kostplaneringssystem: Den föreslagna lösningen ska leverera öppna data enligt den nationella definitionen som finns på: [orebrokommun.github.io/Open-Meal-Information/](http://orebrokommun.github.io/Open-Meal-Information/)
+2. Ställ krav på leverantörer vid upphandling av kostplaneringssystem: Den föreslagna lösningen ska leverera öppna data enligt den nationella definitionen som finns på: [sambruk.github.io/Open-Meal/](https://sambruk.github.io/Open-Meal/)
 
 För mer information om öppna måltidsdata och återanvändning av information rekommenderar vi [vidareutnyttjande.se](http://www.vidareutnyttjande.se). 

--- a/_posts/2015-08-26-svenska.md
+++ b/_posts/2015-08-26-svenska.md
@@ -16,8 +16,8 @@ Har du några frågor eller förslag till utveckling redan nu? Skicka dem till [
 ##Exempel
 Bilden nedan visar hur det ser ut i en elektronisk kalender när man prenumererar på matsedeln för skolan Bruket i Örebro. [Här kan du själv testa att prenumerera på den kalendern (klicka på ”Kalender” i menyn till vänster på sidan du kommer till)](https://mpi.mashie.eu/public/app/%C3%96rebro%20kommun/C7A32CE6).
 
-<img src="/Open-Meal-Information/img/Kalender-maltidsinformation-crop.png"><br/>
-<img src="/Open-Meal-Information/img/Kalender-maltidsinformation-crop-expanded.png">
+<img src="/Open-Meal/img/Kalender-maltidsinformation-crop.png"><br/>
+<img src="/Open-Meal/img/Kalender-maltidsinformation-crop-expanded.png">
 
 ##Licens
 All tillgänglig data i öppna måltidsdata API publiceras under Creative Commons licens CC0. Detta ger användaren fullständiga rättigheter att ändra data och använda den för kommersiella ändamål.

--- a/_posts/2016-07-21-widget.md
+++ b/_posts/2016-07-21-widget.md
@@ -14,12 +14,12 @@ The widget consists of two HTML tags - one <code>div</code> and one <code>script
 Example:
 
 <pre><code>&lt;div id=&quot;openMealWidget&quot; class=&quot;openMealWidget&quot; data-openmealurl=&quot;https://skolmaten.se/api/openmeal/v2/meals.json?distributorID=5323089923538944&quot;&gt;&lt;/div&gt;
-&lt;script src=&quot;https://orebrokommun.github.io/Open-Meal-Information/js/widget.js&quot; id=&quot;openMealWidgetScript&quot; data-widgets=&quot;openMealWidget&quot;&gt;&lt;/script&gt;</code></pre>
+&lt;script src=&quot;https://sambruk.github.io/Open-Meal/js/widget.js&quot; id=&quot;openMealWidgetScript&quot; data-widgets=&quot;openMealWidget&quot;&gt;&lt;/script&gt;</code></pre>
 
 The code above results in this table:
 
 <div id="openMealWidget" class="openMealWidget" data-openmealurl="https://skolmaten.se/api/openmeal/v2/meals.json?distributorID=5323089923538944"></div>
-<script src="https://orebrokommun.github.io/Open-Meal-Information/js/widget.js" id="openMealWidgetScript" data-widgets="openMealWidget"></script>
+<script src="https://sambruk.github.io/Open-Meal/js/widget.js" id="openMealWidgetScript" data-widgets="openMealWidget"></script>
 
 ###Wizard
 
@@ -73,7 +73,7 @@ The <code>script</code> tag also have some attributes...
 
 &lt;div id=&quot;openMealWidget2&quot; class="openMealWidget" data-ical=&quot;true&quot; data-days=&quot;3&quot; data-language=&quot;sv&quot; data-openmealurl=&quot;http://meny.dinskolmat.se/api/openmeal/v2/meals.json?distributorID=5323089923538944&quot;&gt;&lt;/div&gt;
 
-&lt;script src=&quot;https://orebrokommun.github.io/Open-Meal-Information/js/widget.js&quot; id=&quot;openMealWidgetScript&quot; data-widgets=&quot;openMealWidget1, openMealWidget2&quot;&gt;&lt;/script&gt;</code></pre>
+&lt;script src=&quot;https://sambruk.github.io/Open-Meal/js/widget.js&quot; id=&quot;openMealWidgetScript&quot; data-widgets=&quot;openMealWidget1, openMealWidget2&quot;&gt;&lt;/script&gt;</code></pre>
 
 ###Style
 
@@ -82,4 +82,4 @@ The styling of the widget is based on [Bootstrap](http://getbootstrap.com/) clas
 ###License and customization
 This widget and it's code is available under Creative Commons Zero license and has no guarantees. Use it, copy it and customize it as needed. 
 
-[The widgets code is available here](https://orebrokommun.github.io/Open-Meal-Information/js/widget.js).
+[The widgets code is available here](https://sambruk.github.io/Open-Meal/js/widget.js).

--- a/datasets/dcat
+++ b/datasets/dcat
@@ -20,7 +20,7 @@
 	<dcterms:description xml:lang="en">API to get data about what food is being served at large kitchens, like schools and elderly care homes. Data already available for all schools in Sweden that is using the Skolmatappen as well as available for Swedish schools using Mashie that has requested that the menu data is published as open data.</dcterms:description>
 	<dcat:dataset rdf:resource="https://dcat-editor.com/store/28/resource/2"/>
 	<dcterms:publisher rdf:resource="https://dcat-editor.com/store/28/resource/7"/>
-	<foaf:homepage>http://orebrokommun.github.io/Open-Meal-Information</foaf:homepage>
+	<foaf:homepage>https://sambruk.github.io/Open-Meal</foaf:homepage>
 	<dcterms:issued>2015-12-16</dcterms:issued>
 	<dcterms:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/"/>
 	<dcterms:language rdf:resource="http://publications.europa.eu/resource/authority/language/SWE"/>
@@ -73,7 +73,7 @@
 	<dcterms:issued>2015-09-18</dcterms:issued>
 	<dcat:theme rdf:resource="http://eurovoc.europa.eu/100157"/>
 	<dcterms:accrualPeriodicity rdf:resource="http://purl.org/cld/freq/continuous"/>
-	<dcat:landingPage rdf:resource="http://orebrokommun.github.io/Open-Meal-Information/"/>
+	<dcat:landingPage rdf:resource="https://sambruk.github.io/Open-Meal/"/>
 	<dcterms:language rdf:resource="http://publications.europa.eu/resource/authority/language/SWE"/>
 	<adms:version>2</adms:version>
 </dcat:Dataset>
@@ -139,10 +139,10 @@
 	<dcterms:title xml:lang="sv">Lista dataleverantörer </dcterms:title>
 	<dcterms:description xml:lang="en">An API-anrop to get all the open meal data providers that in turn can provide menus etc.</dcterms:description>
 	<dcterms:description xml:lang="sv">Ett API-anrop för att hämta information om alla Open Meals dataleverantörer. Dessa kan sedan i sin tur tillhandahålla menyinformation etc.</dcterms:description>
-	<dcat:accessURL rdf:resource="https://raw.githubusercontent.com/Orebrokommun/Open-Meal-Information/master/dataproviders.json"/>
+	<dcat:accessURL rdf:resource="https://raw.githubusercontent.com/Sambruk/Open-Meal/master/dataproviders.json"/>
 	<dcterms:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/"/>
 	<dcterms:format>application/json</dcterms:format>
-	<dcat:downloadURL rdf:resource="https://raw.githubusercontent.com/Orebrokommun/Open-Meal-Information/master/dataproviders.json"/>
+	<dcat:downloadURL rdf:resource="https://raw.githubusercontent.com/Sambruk/Open-Meal/master/dataproviders.json"/>
 	<dcterms:rights>
 		<odrs:RightsStatement rdf:nodeID="node1a6q8mj0cx1">
 			<odrs:copyrightHolder rdf:resource="https://dcat-editor.com/store/28/resource/7"/>

--- a/index.md
+++ b/index.md
@@ -8,16 +8,16 @@ The goal is to create a way to create open data about menus, ingredients, nutrit
 
 The specification and other information for how to create open meal information can be found on this webpage and as it is on Github anyone can fork and develop it. There are two implementations of the specification:
 
-* An [API](/Open-Meal-Information/doc/basics.html) with the full data set in JSON format
-* [iCalendar](/Open-Meal-Information/doc/icalendar.html) with a subset of the information. The calendar-feed can be used by smartphones and pads as well as other calendar software to subscribe to the information.
+* An [API](/Open-Meal/doc/basics.html) with the full data set in JSON format
+* [iCalendar](/Open-Meal/doc/icalendar.html) with a subset of the information. The calendar-feed can be used by smartphones and pads as well as other calendar software to subscribe to the information.
 
 Questions and suggestions can be sent to [andreas.krohn@helsingborg.se](mailto:andreas.krohn@helsingborg.se).
 
 ##Example
 This is an example of [an iCalendar feed available for subscription for the school ”Bruket” in Örebro, Sweden](https://mpi.mashie.eu/public/app/%C3%96rebro%20kommun/C7A32CE6). The page is in swedish but the subscription link is called ”Kalender” and is located in the menu on the left. Copy the link for use in your calendar software or just click it, most devices will ask you if you want to subscribe. This is what it will look like on an ipad:
 
-<img src="/Open-Meal-Information/img/Kalender-maltidsinformation-crop.png"><br/>
-<img src="/Open-Meal-Information/img/Kalender-maltidsinformation-crop-expanded.png">
+<img src="/Open-Meal/img/Kalender-maltidsinformation-crop.png"><br/>
+<img src="/Open-Meal/img/Kalender-maltidsinformation-crop-expanded.png">
 
 ##The History
 The open meal information project was started by 3 municipalities in Sweden - [Helsingborg](http://www.helsingborg.se/), [Linköping](http://linkoping.se/) and [Örebro](http://www.orebro.se/). The goal was to make sure all municipalities in Sweden shared information about meals as menus in the same way so it would be easier to reuse. The goal was to create open data.

--- a/js/wizard.js
+++ b/js/wizard.js
@@ -1,5 +1,5 @@
 $(function() {	
-	var openMealDataProviderURL = 'https://raw.githubusercontent.com/Orebrokommun/Open-Meal-Information/master/dataproviders.json';
+	var openMealDataProviderURL = 'https://raw.githubusercontent.com/Sambruk/Open-Meal/master/dataproviders.json';
 
 	// Populate initial data provider drop down
   	var dataProiderXHR = $.getJSON(openMealDataProviderURL, function(response){  		
@@ -61,7 +61,7 @@ $(function() {
   		var currentProvider = $("#openMealWizard #dataProviders option:selected");  		
   		var openMealURL = currentProvider.data('baseurl') + '/openmeal/v2/meals.json?distributorID=' + currentOption.val();
   		var code = '<div id="openMealWidget" data-language="' + currentOption.data('language') + '" data-openmealurl="' + openMealURL + '"></div>\n' +  		
-    			   '<script src="https://orebrokommun.github.io/Open-Meal-Information/js/widget.js" id="openMealWidgetScript" data-widgets="openMealWidget"></script>';
+    			   '<script src="https://sambruk.github.io/Open-Meal/js/widget.js" id="openMealWidgetScript" data-widgets="openMealWidget"></script>';
 
 		$('#openMealWizard #openMealWidgetCode code').text(code);   		
 


### PR DESCRIPTION
Went through the code base and changed all url references (relative and full paths) so they point to our new adresses sambruk.github.io & /Open-Meal instead of Orebro