### PR TITLE
change terminology from provider to DataProvider

### DIFF
--- a/OpenAPI-Specification-DataProviders.yml
+++ b/OpenAPI-Specification-DataProviders.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  title: Data providers API
+  title: Data Providers API
   description: API used to serve the data providers info. A data provider provides the basePath where the Open Meal information is served.
     Read more on [https://sambruk.github.io/Open-Meal/](https://sambruk.github.io/Open-Meal/)
   version: '1.0'
@@ -13,7 +13,7 @@ paths:
   /dataproviders:
     get:
       tags:
-        - Data providers
+        - Data Providers
       summary: Returns a list of data providers (for example Matilda, Mashie, Skolmaten etc.). A data provider provides the basePath where the Open Meal information is served for it's distributors.
       responses:
         '200':
@@ -54,7 +54,7 @@ components:
       properties:
         baseUrl:
           type: string
-          description: The Base URL is where the Data provider serves the Open Meal API endpoints
+          description: The Base URL is where the data provider serves the Open Meal API endpoints
         email:
           type: string
           nullable: true

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Site based on the [jekyll-docs-template](http://bruth.github.io/jekyll-docs-temp
 View specification in [Swagger editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/Sambruk/Open-Meal/main/OpenAPI-Specification.yml).
 
 
-## Dataprovider
+## Data Provider
 View the specification for the dataprovider endpoint in [Swagger editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/Sambruk/Open-Meal/main/OpenAPI-Specification-DataProviders.yml).
 
-### Data provider endpoint
+### Data Provider Endpoint
 The data providers are served using the nifty little github pages feature that allows for a static json file beeing returned as application/json automatically from within a folder.
 
 * The folder should be named as the intended endpoint.

--- a/website/docs/API/data_providers.md
+++ b/website/docs/API/data_providers.md
@@ -2,13 +2,13 @@
 sidebar_position: 3
 ---
 
-# Providers
+# Data providers
 
-A provider is an implementor of the API that can enable access to organisations and third-party developers interested in using it.
+A Data provider is an implementor of the API that can enable access to organisations and third-party developers interested in using it.
 
-## Known providers
+## Known Data providers
 
-You can issue a GET request to the following URL to get an up-to-date list of data providers supporting  version 3.x of the Open Meal API.
+You can issue a GET request to the following URL to get an up-to-date list of dataProviders supporting version 3.x of the Open Meal API.
 
 It will list a number of properties including the `baseUrl` which should be used in all Open Meal requests towards the provider.
 
@@ -21,7 +21,7 @@ See the full specification of the Data Provider API:
 - In the [Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/Sambruk/Open-Meal/main/OpenAPI-Specification-DataProviders.yml)
 
 
-## Add provider
+## Add a Data provider
 In order to appear as a Data provider your info must be added to the file [/website/static/api/dataproviders/index.json](https://github.com/Sambruk/Open-Meal/tree/main/website/static/api/dataprovider/index.json).
 
 If you want to be added to the list of data providers, [CREATE AN ISSUE](https://github.com/Sambruk/Open-Meal/issues) in the project or contact any of the project members for assistance.

--- a/website/docs/API/data_providers.md
+++ b/website/docs/API/data_providers.md
@@ -2,11 +2,11 @@
 sidebar_position: 3
 ---
 
-# Data providers
+# Data Providers
 
-A Data provider is an implementor of the API that can enable access to organisations and third-party developers interested in using it.
+A data provider is an implementor of the API that can enable access to organisations and third-party developers interested in using it.
 
-## Known Data providers
+## Known Data Providers
 
 You can issue a GET request to the following URL to get an up-to-date list of dataProviders supporting version 3.x of the Open Meal API.
 
@@ -16,13 +16,13 @@ It will list a number of properties including the `baseUrl` which should be used
 GET https://sambruk.github.io/Open-Meal/api/dataproviders/
 ```
 
-See the full specification of the Data Provider API:
+See the full specification of the data provider API:
 - As a [raw yml file](https://raw.githubusercontent.com/Sambruk/Open-Meal/main/OpenAPI-Specification-DataProviders.yml)
 - In the [Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/Sambruk/Open-Meal/main/OpenAPI-Specification-DataProviders.yml)
 
 
-## Add a Data provider
-In order to appear as a Data provider your info must be added to the file [/website/static/api/dataproviders/index.json](https://github.com/Sambruk/Open-Meal/tree/main/website/static/api/dataprovider/index.json).
+## Add a Data Provider
+In order to appear as a data provider your info must be added to the file [/website/static/api/dataproviders/index.json](https://github.com/Sambruk/Open-Meal/tree/main/website/static/api/dataprovider/index.json).
 
 If you want to be added to the list of data providers, [CREATE AN ISSUE](https://github.com/Sambruk/Open-Meal/issues) in the project or contact any of the project members for assistance.
 

--- a/website/docs/API/icalendar.md
+++ b/website/docs/API/icalendar.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 iCalendar is a file format that is used to show events in a calendar. A limited version of the Open Meal data can be published in iCalendar format according to the following specification. It makes the meal information usable in a large number of applications, like Microsoft Outlook, Apple Calendar and Google Calendar.
 
-Implementation of the iCalendar feature is optional but strongly recommended for providers. If the iCalendar feature is implemented, the URL to the iCalendar should be made availale via the [distributor](/openapi-specification#tag/Distributor).
+Implementation of the iCalendar feature is optional but strongly recommended for Data providers. If the iCalendar feature is implemented, the URL to the iCalendar should be made availale via the [distributor](/openapi-specification#tag/Distributor).
 
 ## Calendars
 

--- a/website/docs/API/icalendar.md
+++ b/website/docs/API/icalendar.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 iCalendar is a file format that is used to show events in a calendar. A limited version of the Open Meal data can be published in iCalendar format according to the following specification. It makes the meal information usable in a large number of applications, like Microsoft Outlook, Apple Calendar and Google Calendar.
 
-Implementation of the iCalendar feature is optional but strongly recommended for Data providers. If the iCalendar feature is implemented, the URL to the iCalendar should be made availale via the [distributor](/openapi-specification#tag/Distributor).
+Implementation of the iCalendar feature is optional but strongly recommended for data providers. If the iCalendar feature is implemented, the URL to the iCalendar should be made availale via the [distributor](/openapi-specification#tag/Distributor).
 
 ## Calendars
 

--- a/website/docs/API/specification.md
+++ b/website/docs/API/specification.md
@@ -10,4 +10,4 @@ The API is described in an [OpenAPI specification](https://swagger.io/specificat
 - As a [raw yml file](https://github.com/Sambruk/Open-Meal/blob/main/OpenAPI-Specification.yml)
 - In the [Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/Sambruk/Open-Meal/main/OpenAPI-Specification.yml)
 
-Note that the specification does not contain URL:s with domain names so you will need to prepend those when making requests towards your chosen [provider](/docs/api/providers). Also note you might need to add authentication headers to make requests towards a certain provider. Other potential differences in provider implementations should be documented on the [providers](/docs/api/providers) page.
+Note that the specification does not contain URL:s with domain names so you will need to prepend those when making requests towards your chosen [Data provider](/docs/api/data_providers). Also note you might need to add authentication headers to make requests towards a certain provider. Other potential differences in provider implementations should be documented on the [Data provider](/docs/api/data_providers) page.

--- a/website/docs/API/specification.md
+++ b/website/docs/API/specification.md
@@ -10,4 +10,4 @@ The API is described in an [OpenAPI specification](https://swagger.io/specificat
 - As a [raw yml file](https://github.com/Sambruk/Open-Meal/blob/main/OpenAPI-Specification.yml)
 - In the [Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/Sambruk/Open-Meal/main/OpenAPI-Specification.yml)
 
-Note that the specification does not contain URL:s with domain names so you will need to prepend those when making requests towards your chosen [Data provider](/docs/api/data_providers). Also note you might need to add authentication headers to make requests towards a certain provider. Other potential differences in provider implementations should be documented on the [Data provider](/docs/api/data_providers) page.
+Note that the specification does not contain URL:s with domain names so you will need to prepend those when making requests towards your chosen [data provider](/docs/api/data_providers). Also note you might need to add authentication headers to make requests towards a certain provider. Other potential differences in provider implementations should be documented on the [data provider](/docs/api/data_providers) page.

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Introduction
 
-The goal for Open Meal is to facilitate a way for municipalities and organisations to openly share menus from their meal distributors (schools, retirement homes and more). Data is shared through [providers](/docs/api/providers) and can be consumed by third-party developers to build custom applications on top of it.
+The goal for Open Meal is to facilitate a way for municipalities and organisations to openly share menus from their meal distributors (schools, retirement homes and more). Data is shared through [Data providers](/docs/api/data_providers) and can be consumed by third-party developers to build custom applications on top of it.
 
 The Open Meal API consists of two parts:
 

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Introduction
 
-The goal for Open Meal is to facilitate a way for municipalities and organisations to openly share menus from their meal distributors (schools, retirement homes and more). Data is shared through [Data providers](/docs/api/data_providers) and can be consumed by third-party developers to build custom applications on top of it.
+The goal for Open Meal is to facilitate a way for municipalities and organisations to openly share menus from their meal distributors (schools, retirement homes and more). Data is shared through [data providers](/docs/api/data_providers) and can be consumed by third-party developers to build custom applications on top of it.
 
 The Open Meal API consists of two parts:
 


### PR DESCRIPTION
Changed provider(s) to Data provider where applicable to keep a consistent terminology regarding DataProviders.

(Build has been successfully tested locally)