### PR TITLE
Bump version to 3.4

### DIFF
--- a/OpenAPI-Specification.yml
+++ b/OpenAPI-Specification.yml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: Open Meal
   description: ""
-  version: "3.3"
+  version: "3.4"
 paths:
   /distributors:
     get:
@@ -27,7 +27,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DistributorsListResponse'
+                $ref: "#/components/schemas/DistributorsListResponse"
   /distributors/{distributorId}:
     get:
       tags:
@@ -110,80 +110,73 @@ paths:
                 meals:
                   value:
                     {
-                        "meals": [
+                      "meals":
+                        [
                           {
                             "name": "Lunch 1",
                             "date": "2022-06-16",
                             "lang": null,
                             "description": null,
                             "order": 0,
-                            "distributor": {
-                              "id": "923608a6-e294-4149-ac79-a19f6e7adfd7",
-                              "name": "Matkund 1",
-                              "organization": Matköping
-                            },
-                            "courses": [
+                            "distributor":
                               {
-                                "id": "8f86e3ae-6c42-4ef3-bd32-d3de426ad3ec",
-                                "name": "Fransk pastagratäng med kyckling",
-                                "description": "Krämig pastagratäng med dragonkryddad kyckling och tre sorters ost",
-                                "optionName": "Lunch 1",
-                                "order": 0,
-                                "labelOfContents": "Kycklingfond , GratängOST 28%, Lasagnette, Salt, SENAP Dijon, VispGRÄDDE, Pastakyckling, Paprika röd strimlad, Svartpeppar mald, MellanMJÖLK 1,5% 10L  EKO",
-                                "ingredients": [
-                                  {
-                                    "name": "Kycklingfond ",
-                                    "codes": []
-                                  },
-                                  {
-                                    "name": "GratängOST 28%",
-                                    "codes": []
-                                  }
-                                ],
-                                "media": [],
-                                "knownAllergens": [
-                                  {
-                                    "name": "Selleri",
-                                    "codes": [
+                                "id": "923608a6-e294-4149-ac79-a19f6e7adfd7",
+                                "name": "Matkund 1",
+                                "organization": Matköping,
+                              },
+                            "courses":
+                              [
+                                {
+                                  "id": "8f86e3ae-6c42-4ef3-bd32-d3de426ad3ec",
+                                  "name": "Fransk pastagratäng med kyckling",
+                                  "description": "Krämig pastagratäng med dragonkryddad kyckling och tre sorters ost",
+                                  "optionName": "Lunch 1",
+                                  "order": 0,
+                                  "labelOfContents": "Kycklingfond , GratängOST 28%, Lasagnette, Salt, SENAP Dijon, VispGRÄDDE, Pastakyckling, Paprika röd strimlad, Svartpeppar mald, MellanMJÖLK 1,5% 10L  EKO",
+                                  "ingredients":
+                                    [
+                                      { "name": "Kycklingfond ", "codes": [] },
+                                      { "name": "GratängOST 28%", "codes": [] },
+                                    ],
+                                  "media": [],
+                                  "knownAllergens":
+                                    [
                                       {
-                                        "code": "BC",
-                                        "type": "GS1"
-                                      }
-                                    ]
-                                  }
-                                ],
-                                "tags": [],
-                                "nutrients": [
-                                  {
-                                    "name": "Energi (kJ)",
-                                    "amount": 1958.69,
-                                    "unit": "kJ",
-                                    "codes": [
+                                        "name": "Selleri",
+                                        "codes":
+                                          [{ "code": "BC", "type": "GS1" }],
+                                      },
+                                    ],
+                                  "tags": [],
+                                  "nutrients":
+                                    [
                                       {
-                                        "code": "ENKJ",
-                                        "type": "GS1"
-                                      }
-                                    ]
-                                  }
-                                ],
-                                "prices": [
-                                  {
-                                      "name": "Barn",
-                                      "value": 55,
-                                      "currency": "SEK"
-                                  },
-                                  {
-                                      "name": "Normal",
-                                      "value": 75.95,
-                                      "currency": "SEK"
-                                  }
-                                ],
-                                "co2Equivalents": 0.58
-                              }
-                            ]
-                          }
-                        ]
-                      }
+                                        "name": "Energi (kJ)",
+                                        "amount": 1958.69,
+                                        "unit": "kJ",
+                                        "codes":
+                                          [{ "code": "ENKJ", "type": "GS1" }],
+                                      },
+                                    ],
+                                  "prices":
+                                    [
+                                      {
+                                        "name": "Barn",
+                                        "value": 55,
+                                        "currency": "SEK",
+                                      },
+                                      {
+                                        "name": "Normal",
+                                        "value": 75.95,
+                                        "currency": "SEK",
+                                      },
+                                    ],
+                                  "co2Equivalents": 0.58,
+                                },
+                              ],
+                          },
+                        ],
+                    }
         "400":
           description: Bad Request
           content:
@@ -505,8 +498,8 @@ components:
       additionalProperties: false
     Price:
       required:
-      - name
-      - value
+        - name
+        - value
       type: object
       properties:
         name:


### PR DESCRIPTION
Following the change of "price" -> "prices" and the addition of the "order" property on meals there is a need to increase the version.